### PR TITLE
Remove static words

### DIFF
--- a/index.tpl
+++ b/index.tpl
@@ -53,8 +53,8 @@
 		<li><a href="#tabYear" data-toggle="tab">{translate key="plugins.generic.statistics.lastYears"}</a></li>
 		{* <li><a href="#tabWeek" data-toggle="tab">{translate key="plugins.generic.statistics.lastDays"}</a></li> *}
 		<li><a href="#tabByCountry" data-toggle="tab">{translate key="plugins.generic.statistics.byCountry"}</a></li>
-		<li><a href="#tabArticleDownload" data-toggle="tab">{translate key="plugins.generic.statistics.article"} (Download)</a></li>
-		<li><a href="#tabArticleAbstract" data-toggle="tab">{translate key="plugins.generic.statistics.article"} (Abstract)</a></li>
+		<li><a href="#tabArticleDownload" data-toggle="tab">{translate key="plugins.generic.statistics.article"} ({translate key="plugins.generic.statistics.downloads"})</a></li>
+		<li><a href="#tabArticleAbstract" data-toggle="tab">{translate key="plugins.generic.statistics.article"} ({translate key="common.abstract"})</a></li>
 		<li><a href="#tabIssues" data-toggle="tab">{translate key="plugins.generic.statistics.issues"}</a></li>
 	</ul>
 	<br><br>

--- a/locale/pt_BR/locale.po
+++ b/locale/pt_BR/locale.po
@@ -11,6 +11,10 @@ msgstr ""
 "PO-Revision-Date: 2023-10-05T20:30:31+00:00\n"
 "Language: \n"
 
+
+msgid "plugins.generic.statistics.titlePage"
+msgstr "Estatísticas"
+
 msgid "plugins.generic.statistics.description"
 msgstr "Gráficos estatísticos. Visualização gráfica das estatísticas da tabela 'METRICS'"
 

--- a/locale/pt_BR/locale.po
+++ b/locale/pt_BR/locale.po
@@ -34,10 +34,10 @@ msgid "plugins.generic.statistics.article"
 msgstr "Artigos"
 
 msgid "plugins.generic.statistics.nameArticle"
-msgstr "Nome do artigo"
+msgstr "Título do Artigo"
 
 msgid "plugins.generic.statistics.nameIssue"
-msgstr "Número da edição"
+msgstr "Título da Edição"
 
 msgid "plugins.generic.statistics.downloads"
 msgstr "Downloads"

--- a/version.xml
+++ b/version.xml
@@ -14,8 +14,8 @@
 <version>
 	<application>statistics</application>
 	<type>plugins.generic</type>
-	<release>2.1.1.0</release>
-	<date>2023-10-05</date>
+	<release>2.1.2.0</release>
+	<date>2023-10-10</date>
 	<lazy-load>1</lazy-load>
 	<sitewide>1</sitewide>
 	<class>StatisticsPlugin</class>


### PR DESCRIPTION
Hello again, @xdnan7! :smile: 
So, these changes remove "Download" and "Abstract" static words because translation in portuguese(pt_BR) and spanish(es_ES) is inappropriate.