### PR TITLE
Change ordering in metrics by country from "ASC" to "DESC"

### DIFF
--- a/StatisticsChartsDAO.inc.php
+++ b/StatisticsChartsDAO.inc.php
@@ -70,7 +70,7 @@ class StatisticsChartsDAO extends MetricsDAO {
 	
 	function getMetricsByCountryType($journalId, $assoc_type, $year) {
 		$result = $this->retrieve(
-			'SELECT country_id, SUM(metric) AS sum_metric FROM metrics WHERE context_id = ? AND assoc_type = ? AND SUBSTR(month,1,4) = ? GROUP BY country_id order by SUM(metric) ASC LIMIT 20;',
+			'SELECT country_id, SUM(metric) AS sum_metric FROM metrics WHERE context_id = ? AND assoc_type = ? AND SUBSTR(month,1,4) = ? GROUP BY country_id order by SUM(metric) DESC LIMIT 20;',
 			array((int) $journalId, (int) $assoc_type, $year)
 		);
 

--- a/version.xml
+++ b/version.xml
@@ -14,8 +14,8 @@
 <version>
 	<application>statistics</application>
 	<type>plugins.generic</type>
-	<release>2.1.2.0</release>
-	<date>2023-10-10</date>
+	<release>2.1.3.0</release>
+	<date>2023-11-08</date>
 	<lazy-load>1</lazy-load>
 	<sitewide>1</sitewide>
 	<class>StatisticsPlugin</class>


### PR DESCRIPTION
In the retrieval of metrics by country, the result is ordered by ascending.  

It looks like this is an unexpected behaviour, and instead the results should be the first 20 in DESCending order.
