### PR TITLE
Fix request retrieval code

### DIFF
--- a/StatisticsHandler.inc.php
+++ b/StatisticsHandler.inc.php
@@ -52,7 +52,7 @@ class StatisticsHandler extends Handler {
 	
 	
 	function getStatisticsWeek() {
-		$request = Application::getRequest();
+		$request = \Application::get()->getRequest();
 		$journal = $request->getJournal();
 		
 		//statistics report
@@ -91,7 +91,7 @@ class StatisticsHandler extends Handler {
 	 */
 
 	function getStatisticsByMonth() {
-		$request = Application::getRequest();
+		$request = \Application::get()->getRequest();
 		$journal =& $request->getJournal();
 
 		$year = $request->getUserVar('year');
@@ -124,7 +124,7 @@ class StatisticsHandler extends Handler {
 	 * Get statistics (download and abstract) by year from table METRICS
 	 */
 	function getStatisticsByYear() {
-		$request = Application::getRequest();
+		$request = \Application::get()->getRequest();
 		$journal =& $request->getJournal();
 		$year = $request->getUserVar('year');
 		if (empty($year)) $year = date('Y');
@@ -154,7 +154,7 @@ class StatisticsHandler extends Handler {
 	 * Get statistics (abstract) by country from table METRICS
 	 */
 	function getStatisticsByCountryAbstract() {
-		$request = Application::getRequest();
+		$request = \Application::get()->getRequest();
 		$journal =& $request->getJournal();
 		$year = $request->getUserVar('year');
 		if (empty($year)) $year = date('Y');
@@ -181,7 +181,7 @@ class StatisticsHandler extends Handler {
 	 * Get statistics (download) by country from table METRICS
 	 */
 	function getStatisticsByCountryDownload() {
-		$request = Application::getRequest();
+		$request = \Application::get()->getRequest();
 		$journal =& $request->getJournal();
 		$year = $request->getUserVar('year');
 		if (empty($year)) $year = date('Y');
@@ -206,7 +206,7 @@ class StatisticsHandler extends Handler {
 	 * Get statistics (download or abstract, request parameter) most popular articles from table METRICS
 	 */
 	function getStatisticsMostPopularDownload() {
-		$request = Application::getRequest();
+		$request = \Application::get()->getRequest();
 		$journal =& $request->getJournal();
 		$primaryLocale = $journal->getPrimaryLocale();
 
@@ -235,7 +235,7 @@ class StatisticsHandler extends Handler {
 	 * Get statistics (download) most popular articles from table METRICS
 	 */
 	function getStatisticsIssues() {
-		$request = Application::getRequest();
+		$request = \Application::get()->getRequest();
 		$journal =& $request->getJournal();
 		$primaryLocale = $journal->getPrimaryLocale();
 

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -36,7 +36,7 @@
 	<message key="plugins.generic.statistics.downloadByCountries">Downloads</message>
 	<message key="plugins.generic.statistics.viewAbstracts">Views</message>
 	<message key="plugins.generic.statistics.viewAbstractsByCountry">Article abstract page views</message>
-	<message key="plugins.generic.statistics.viewDownloads">Donwloads</message>
+	<message key="plugins.generic.statistics.viewDownloads">Downloads</message>
 	<message key="plugins.generic.statistics.lastYears2">Last 6 years</message>
 	<message key="plugins.generic.statistics.byMonthArticle">Last 12 months</message>
 	<message key="plugins.generic.statistics.byMonth">For months of the year</message>

--- a/locale/pt_BR/locale.po
+++ b/locale/pt_BR/locale.po
@@ -85,7 +85,7 @@ msgid "plugins.generic.statistics.viewAbstractsByCountry"
 msgstr "Visualizações da página de resumo do artigo"
 
 msgid "plugins.generic.statistics.viewDownloads"
-msgstr "Donwloads"
+msgstr "Downloads"
 
 msgid "plugins.generic.statistics.lastYears2"
 msgstr "Últimos 6 anos"

--- a/locale/pt_BR/locale.xml
+++ b/locale/pt_BR/locale.xml
@@ -38,7 +38,7 @@
 	<message key="plugins.generic.statistics.downloadByCountries">Downloads</message>
 	<message key="plugins.generic.statistics.viewAbstracts">Visualizações</message>
 	<message key="plugins.generic.statistics.viewAbstractsByCountry">Visualizações da página de resumo do artigo</message>
-	<message key="plugins.generic.statistics.viewDownloads">Donwloads</message>
+	<message key="plugins.generic.statistics.viewDownloads">Downloads</message>
 	<message key="plugins.generic.statistics.lastYears2">Últimos 6 anos</message>
 	<message key="plugins.generic.statistics.byMonthArticle">Últimos 12 meses</message>
 	<message key="plugins.generic.statistics.byMonth">Por meses do ano</message>


### PR DESCRIPTION
This PR includes a fix for the following error in obtaining the Request in OJS 3.3:

```sh
PHP Fatal error:  Uncaught Error: Non-static method PKPApplication::getRequest() cannot be called statically 
```

In addition, I took the opportunity to fix the text ‘Downloads’.